### PR TITLE
[feat] 대댓글 작성 및 조회 API 구현

### DIFF
--- a/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
+++ b/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
@@ -1,14 +1,17 @@
 package org.com.itpple.spot.server.controller;
 
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.com.itpple.spot.server.common.auth.Auth;
 import org.com.itpple.spot.server.common.auth.userDetails.CustomUserDetails;
+import org.com.itpple.spot.server.dto.comment.CommentDto;
 import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
 import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
 import org.com.itpple.spot.server.service.impl.CommentServiceImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,5 +35,16 @@ public class CommentController {
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(commentServiceImpl.addComment(userId, potId, createCommentRequest));
+    }
+
+    @GetMapping("/{potId}")
+    public ResponseEntity<List<CommentDto>> getComments(
+        @Auth CustomUserDetails customUserDetails,
+        @PathVariable Long potId
+    ) {
+        Long userId = customUserDetails.getUserId();
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(commentServiceImpl.getCommentList(userId, potId));
     }
 }

--- a/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
+++ b/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
@@ -8,7 +8,7 @@ import org.com.itpple.spot.server.common.auth.userDetails.CustomUserDetails;
 import org.com.itpple.spot.server.dto.comment.CommentDto;
 import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
 import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
-import org.com.itpple.spot.server.service.impl.CommentServiceImpl;
+import org.com.itpple.spot.server.service.CommentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CommentController {
 
-    private final CommentServiceImpl commentServiceImpl;
+    private final CommentService commentService;
 
     @PostMapping("/{potId}")
     public ResponseEntity<CreateCommentResponse> addComment(
@@ -34,7 +34,7 @@ public class CommentController {
         Long userId = customUserDetails.getUserId();
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(commentServiceImpl.addComment(userId, potId, createCommentRequest));
+            .body(commentService.addComment(userId, potId, createCommentRequest));
     }
 
     @GetMapping("/{potId}")
@@ -45,6 +45,6 @@ public class CommentController {
         Long userId = customUserDetails.getUserId();
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(commentServiceImpl.getCommentList(userId, potId));
+            .body(commentService.getCommentList(userId, potId));
     }
 }

--- a/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
+++ b/src/main/java/org/com/itpple/spot/server/controller/CommentController.java
@@ -1,0 +1,36 @@
+package org.com.itpple.spot.server.controller;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.com.itpple.spot.server.common.auth.Auth;
+import org.com.itpple.spot.server.common.auth.userDetails.CustomUserDetails;
+import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
+import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
+import org.com.itpple.spot.server.service.impl.CommentServiceImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comment")
+@RestController
+public class CommentController {
+
+    private final CommentServiceImpl commentServiceImpl;
+
+    @PostMapping("/{potId}")
+    public ResponseEntity<CreateCommentResponse> addComment(
+        @Auth CustomUserDetails customUserDetails,
+        @PathVariable Long potId,
+        @Valid @RequestBody CreateCommentRequest createCommentRequest
+    ) {
+        Long userId = customUserDetails.getUserId();
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(commentServiceImpl.addComment(userId, potId, createCommentRequest));
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/controller/ReactionController.java
+++ b/src/main/java/org/com/itpple/spot/server/controller/ReactionController.java
@@ -6,7 +6,7 @@ import org.com.itpple.spot.server.common.auth.Auth;
 import org.com.itpple.spot.server.common.auth.userDetails.CustomUserDetails;
 import org.com.itpple.spot.server.dto.reaction.request.CreateReactionRequest;
 import org.com.itpple.spot.server.dto.reaction.response.CreateReactionResponse;
-import org.com.itpple.spot.server.service.impl.ReactionServiceImpl;
+import org.com.itpple.spot.server.service.ReactionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ReactionController {
 
-    private final ReactionServiceImpl reactionServiceImpl;
+    private final ReactionService reactionService;
 
     @PostMapping
     public ResponseEntity<CreateReactionResponse> addReaction(
@@ -29,6 +29,6 @@ public class ReactionController {
         Long userId = customUserDetails.getUserId();
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(reactionServiceImpl.addReaction(userId, createReactionRequest));
+            .body(reactionService.addReaction(userId, createReactionRequest));
     }
 }

--- a/src/main/java/org/com/itpple/spot/server/dto/comment/CommentDto.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/comment/CommentDto.java
@@ -12,7 +12,7 @@ import org.com.itpple.spot.server.entity.Comment;
 
 @Builder
 @Getter
-public class CommentDto{
+public class CommentDto {
 
     private Long commentId;
     private String content;
@@ -25,7 +25,7 @@ public class CommentDto{
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     static class UserDto {
         private Long userId;
-        private String ProfileImageUrl;
+        private String profileImageUrl;
         private String name;
     }
 

--- a/src/main/java/org/com/itpple/spot/server/dto/comment/CommentDto.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/comment/CommentDto.java
@@ -1,0 +1,45 @@
+package org.com.itpple.spot.server.dto.comment;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import org.com.itpple.spot.server.entity.Comment;
+
+@Builder
+@Getter
+public class CommentDto{
+
+    private Long commentId;
+    private String content;
+    private LocalDateTime commentUpdatedAt;
+    private UserDto writer;
+    @Default
+    private List<CommentDto> childrenComments = new ArrayList<>();
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    static class UserDto {
+        private Long userId;
+        private String ProfileImageUrl;
+        private String name;
+    }
+
+    public static CommentDto from(Comment comment) {
+        return CommentDto.builder()
+            .commentId(comment.getId())
+            .content(comment.isDeleted() ? "작성자가 삭제한 댓글입니다." : comment.getContent())
+            .commentUpdatedAt(comment.getUpdatedAt())
+            .writer(
+                new UserDto(
+                    comment.getWriter().getId(),
+                    comment.getWriter().getProfileImageUrl(),
+                    comment.getWriter().getName())
+            )
+            .build();
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/dto/comment/request/CreateCommentRequest.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/comment/request/CreateCommentRequest.java
@@ -1,0 +1,9 @@
+package org.com.itpple.spot.server.dto.comment.request;
+
+import javax.validation.constraints.NotBlank;
+
+public record CreateCommentRequest(
+    Long parentCommentId,
+    @NotBlank String content
+) {
+}

--- a/src/main/java/org/com/itpple/spot/server/dto/comment/response/CreateCommentResponse.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/comment/response/CreateCommentResponse.java
@@ -1,0 +1,24 @@
+package org.com.itpple.spot.server.dto.comment.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.com.itpple.spot.server.entity.Comment;
+import org.com.itpple.spot.server.entity.User;
+
+@Builder
+public record CreateCommentResponse(
+    String writerProfileImageUrl,
+    String writerName,
+    LocalDateTime commentUpdatedAt,
+    String content
+) {
+
+    public static CreateCommentResponse from(User user, Comment comment) {
+        return CreateCommentResponse.builder()
+            .writerProfileImageUrl(user.getProfileImageUrl())
+            .writerName(user.getName())
+            .commentUpdatedAt(comment.getUpdatedAt())
+            .content(comment.getContent())
+            .build();
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/dto/comment/response/CreateCommentResponse.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/comment/response/CreateCommentResponse.java
@@ -13,10 +13,10 @@ public record CreateCommentResponse(
     String content
 ) {
 
-    public static CreateCommentResponse from(User user, Comment comment) {
+    public static CreateCommentResponse from(Comment comment) {
         return CreateCommentResponse.builder()
-            .writerProfileImageUrl(user.getProfileImageUrl())
-            .writerName(user.getName())
+            .writerProfileImageUrl(comment.getWriter().getProfileImageUrl())
+            .writerName(comment.getWriter().getName())
             .commentUpdatedAt(comment.getUpdatedAt())
             .content(comment.getContent())
             .build();

--- a/src/main/java/org/com/itpple/spot/server/entity/Comment.java
+++ b/src/main/java/org/com/itpple/spot/server/entity/Comment.java
@@ -1,0 +1,63 @@
+package org.com.itpple.spot.server.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLDeleteAll;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+@SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE comment_id = ?")
+@SQLDeleteAll(sql = "UPDATE comment SET is_deleted = true WHERE comment_id in ?")
+@Entity
+public class Comment extends BasicDateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pot_id", nullable = false)
+    private Pot pot;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private User writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+    private List<Comment> childrenComments = new ArrayList<>();
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
+    private boolean isDeleted;
+
+    @Builder
+    private Comment(Pot pot, User writer, Comment parentComment, String content) {
+        this.pot = pot;
+        this.writer = writer;
+        this.parentComment = parentComment;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/entity/Comment.java
+++ b/src/main/java/org/com/itpple/spot/server/entity/Comment.java
@@ -44,7 +44,7 @@ public class Comment extends BasicDateEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+    @OneToMany(mappedBy = "parentComment")
     private List<Comment> childrenComments = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/org/com/itpple/spot/server/exception/code/ErrorCode.java
+++ b/src/main/java/org/com/itpple/spot/server/exception/code/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
 
     // User 관련
     NOT_FOUND_USER(1401, "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_ID_ALREADY_EXISTS(1402,"이미 존재하는 meberId 입니다", HttpStatus.BAD_REQUEST),
+    NICKNAME_DUPLICATE(1403,"이미 존재하는 닉네임 입니다",HttpStatus.INTERNAL_SERVER_ERROR),
+    NICKNAME_VALIDATION(1404,"공백없이 15자 이하로 작성해주세요 특수문자는 _만 사용 가능해요",HttpStatus.BAD_REQUEST),
 
     // File 관련
     ILLEGAL_FILE_NAME(1501, "파일 이름이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
@@ -33,9 +36,9 @@ public enum ErrorCode {
     // Reaction 관련
     NOT_ADD_MULTIPLE_REACTION(1801, "팟에 여러 개의 반응을 추가할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
-    MEMBER_ID_ALREADY_EXISTS(1901,"이미 존재하는 meberId 입니다", HttpStatus.BAD_REQUEST),
-    NICKNAME_DUPLICATE(1902,"이미 존재하는 닉네임 입니다",HttpStatus.INTERNAL_SERVER_ERROR),
-    NICKNAME_VALIDATION(1903,"공백없이 15자 이하로 작성해주세요 특수문자는 _만 사용 가능해요",HttpStatus.BAD_REQUEST),
+    // Comment 관련
+    NOT_FOUND_PARENT_COMMENT(1901, "답글 추가하기 위한 댓글이 없습니다.", HttpStatus.NOT_FOUND),
+    COMMENT_POT_NOT_MATCH(1902, "추가하려는 답글과 댓글의 POT이 다릅니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final Integer code;

--- a/src/main/java/org/com/itpple/spot/server/exception/comment/CommentPotNotMatchException.java
+++ b/src/main/java/org/com/itpple/spot/server/exception/comment/CommentPotNotMatchException.java
@@ -1,0 +1,11 @@
+package org.com.itpple.spot.server.exception.comment;
+
+import org.com.itpple.spot.server.exception.CustomException;
+import org.com.itpple.spot.server.exception.code.ErrorCode;
+
+public class CommentPotNotMatchException extends CustomException {
+
+    public CommentPotNotMatchException() {
+        super(ErrorCode.COMMENT_POT_NOT_MATCH);
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/exception/comment/ParentCommentNotFoundException.java
+++ b/src/main/java/org/com/itpple/spot/server/exception/comment/ParentCommentNotFoundException.java
@@ -1,0 +1,11 @@
+package org.com.itpple.spot.server.exception.comment;
+
+import org.com.itpple.spot.server.exception.CustomException;
+import org.com.itpple.spot.server.exception.code.ErrorCode;
+
+public class ParentCommentNotFoundException extends CustomException {
+
+    public ParentCommentNotFoundException(String optionalMessage) {
+        super(ErrorCode.NOT_FOUND_PARENT_COMMENT, optionalMessage);
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
+++ b/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package org.com.itpple.spot.server.repository;
+
+import java.util.Optional;
+import org.com.itpple.spot.server.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.pot WHERE c.id = :commentId")
+    Optional<Comment> findByIdWithPot(Long commentId);
+}

--- a/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
+++ b/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
@@ -1,15 +1,11 @@
 package org.com.itpple.spot.server.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.com.itpple.spot.server.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-    @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.pot WHERE c.id = :commentId")
-    Optional<Comment> findByIdWithPot(Long commentId);
 
     @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.parentComment LEFT JOIN FETCH c.writer "
         + "WHERE c.pot.id = :potId ORDER BY c.parentComment.id ASC NULLS FIRST, c.createdAt ASC")

--- a/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
+++ b/src/main/java/org/com/itpple/spot/server/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package org.com.itpple.spot.server.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.com.itpple.spot.server.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.pot WHERE c.id = :commentId")
     Optional<Comment> findByIdWithPot(Long commentId);
+
+    @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.parentComment LEFT JOIN FETCH c.writer "
+        + "WHERE c.pot.id = :potId ORDER BY c.parentComment.id ASC NULLS FIRST, c.createdAt ASC")
+    List<Comment> findAllComment(Long potId);
 }

--- a/src/main/java/org/com/itpple/spot/server/service/CommentService.java
+++ b/src/main/java/org/com/itpple/spot/server/service/CommentService.java
@@ -1,0 +1,9 @@
+package org.com.itpple.spot.server.service;
+
+import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
+import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
+
+public interface CommentService {
+
+    CreateCommentResponse addComment(Long userId, Long potId, CreateCommentRequest request);
+}

--- a/src/main/java/org/com/itpple/spot/server/service/CommentService.java
+++ b/src/main/java/org/com/itpple/spot/server/service/CommentService.java
@@ -1,9 +1,13 @@
 package org.com.itpple.spot.server.service;
 
+import java.util.List;
+import org.com.itpple.spot.server.dto.comment.CommentDto;
 import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
 import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
 
 public interface CommentService {
 
     CreateCommentResponse addComment(Long userId, Long potId, CreateCommentRequest request);
+
+    List<CommentDto> getCommentList(Long userId, Long potId);
 }

--- a/src/main/java/org/com/itpple/spot/server/service/impl/CommentServiceImpl.java
+++ b/src/main/java/org/com/itpple/spot/server/service/impl/CommentServiceImpl.java
@@ -1,0 +1,63 @@
+package org.com.itpple.spot.server.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.com.itpple.spot.server.dto.comment.request.CreateCommentRequest;
+import org.com.itpple.spot.server.dto.comment.response.CreateCommentResponse;
+import org.com.itpple.spot.server.entity.Comment;
+import org.com.itpple.spot.server.entity.Pot;
+import org.com.itpple.spot.server.entity.User;
+import org.com.itpple.spot.server.exception.comment.ParentCommentNotFoundException;
+import org.com.itpple.spot.server.exception.comment.CommentPotNotMatchException;
+import org.com.itpple.spot.server.exception.pot.PotIdNotFoundException;
+import org.com.itpple.spot.server.exception.user.UserIdNotFoundException;
+import org.com.itpple.spot.server.repository.CommentRepository;
+import org.com.itpple.spot.server.repository.PotRepository;
+import org.com.itpple.spot.server.repository.UserRepository;
+import org.com.itpple.spot.server.service.CommentService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PotRepository potRepository;
+
+    @Transactional
+    @Override
+    public CreateCommentResponse addComment(Long userId, Long potId, CreateCommentRequest request) {
+        User writer = userRepository.findById(userId)
+            .orElseThrow(() -> new UserIdNotFoundException("PK = " + userId));
+
+        Pot pot = potRepository.findById(potId)
+            .orElseThrow(() -> new PotIdNotFoundException("PK = " + potId));
+
+        Comment comment = Comment.builder()
+            .writer(writer)
+            .pot(pot)
+            .parentComment(getParentComment(potId, request.parentCommentId()))
+            .content(request.content())
+            .build();
+
+        Comment savedComment = commentRepository.save(comment);
+
+        return CreateCommentResponse.from(writer, savedComment);
+    }
+
+    private Comment getParentComment(Long potId, Long parentCommentId) {
+        Comment parentComment = null;
+
+        if (parentCommentId != null) {
+            parentComment = commentRepository.findByIdWithPot(parentCommentId)
+                .orElseThrow(() -> new ParentCommentNotFoundException("PK = " + parentCommentId));
+            if (parentComment.getPot().getId() != potId) {
+                throw new CommentPotNotMatchException();
+            }
+        }
+
+        return parentComment;
+    }
+}

--- a/src/main/java/org/com/itpple/spot/server/service/impl/CommentServiceImpl.java
+++ b/src/main/java/org/com/itpple/spot/server/service/impl/CommentServiceImpl.java
@@ -49,7 +49,7 @@ public class CommentServiceImpl implements CommentService {
 
         Comment savedComment = commentRepository.save(comment);
 
-        return CreateCommentResponse.from(writer, savedComment);
+        return CreateCommentResponse.from(savedComment);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class CommentServiceImpl implements CommentService {
         Comment parentComment = null;
 
         if (parentCommentId != null) {
-            parentComment = commentRepository.findByIdWithPot(parentCommentId)
+            parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new ParentCommentNotFoundException("PK = " + parentCommentId));
             if (parentComment.getPot().getId() != potId) {
                 throw new CommentPotNotMatchException();


### PR DESCRIPTION
## 🗃 Issue

- Close #50 

## 🔥 Task

- 대댓글을 위한 엔티티 추가
- POT에 대해 대댓글을 작성할 수 있는 API 구현
- POT에 작성된 모든 대댓글 조회할 수 있는 API 구현 

## 📄 Reference

- None
