### PR TITLE
[FEAT] pot 저장 시 userId도 함께 저장

### DIFF
--- a/src/main/java/org/com/itpple/spot/server/dto/pot/request/CreatePotRequest.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/pot/request/CreatePotRequest.java
@@ -19,9 +19,10 @@ public record CreatePotRequest(
         String content
 ) {
 
-    public static Pot toPot(CreatePotRequest createPotRequest) {
+    public static Pot toPot(CreatePotRequest createPotRequest, Long userId) {
         return Pot.builder()
                 .categoryId(createPotRequest.categoryId())
+                .userId(userId)
                 .imageKey(createPotRequest.imageKey())
                 .potType(createPotRequest.type())
                 .content(

--- a/src/main/java/org/com/itpple/spot/server/exception/code/ErrorCode.java
+++ b/src/main/java/org/com/itpple/spot/server/exception/code/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     // Pot 관련
     NOT_FOUND_POT(1701, "팟을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_CATEGORY(1702, "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // Reaction 관련
     NOT_ADD_MULTIPLE_REACTION(1801, "팟에 여러 개의 반응을 추가할 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/org/com/itpple/spot/server/service/impl/PotServiceImpl.java
+++ b/src/main/java/org/com/itpple/spot/server/service/impl/PotServiceImpl.java
@@ -43,13 +43,16 @@ public class PotServiceImpl implements PotService {
 
     @Override
     public CreatePotResponse createPot(Long userId, CreatePotRequest createPotRequest) {
+        if(!categoryRepository.existsById(createPotRequest.categoryId())) {
+            throw new CustomException(ErrorCode.NOT_FOUND_CATEGORY);
+        }
 
         var isUploadedImage = fileService.isUploaded(createPotRequest.imageKey());
         if (!isUploadedImage) {
             throw new CustomException(ErrorCode.INVALID_FILE_KEY);
         }
 
-        return CreatePotResponse.from(potRepository.save(CreatePotRequest.toPot(createPotRequest)));
+        return CreatePotResponse.from(potRepository.save(CreatePotRequest.toPot(createPotRequest, userId)));
     }
 
     @Override


### PR DESCRIPTION
## 🗃 Issue

- Close #60

## 🔥 Task

- pot 저장 시 userId도 함께 저장
- 카테고리가 없을 시 에러

## 📄 Reference

- None
