### PR TITLE
[FIX] pot 저장 시 user 및 category 제대로 저장하게 변경

### DIFF
--- a/src/main/java/org/com/itpple/spot/server/dto/pot/PotDTO.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/pot/PotDTO.java
@@ -29,8 +29,8 @@ public class PotDTO {
     public static PotDTO from(Pot pot) {
         return PotDTO.builder()
                 .id(pot.getId())
-                .userId(pot.getUserId())
-                .categoryId(List.of(pot.getCategoryId()))
+                .userId(pot.getUser().getId())
+                .categoryId(List.of(pot.getCategory().getId()))
                 .potType(pot.getPotType())
                 .content(pot.getContent())
                 .location(PointDTO.from(pot.getLocation()))

--- a/src/main/java/org/com/itpple/spot/server/dto/pot/request/CreatePotRequest.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/pot/request/CreatePotRequest.java
@@ -9,7 +9,9 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import org.com.itpple.spot.server.constant.PotType;
 import org.com.itpple.spot.server.dto.PointDTO;
+import org.com.itpple.spot.server.entity.Category;
 import org.com.itpple.spot.server.entity.Pot;
+import org.com.itpple.spot.server.entity.User;
 
 public record CreatePotRequest(
         @NotNull Long categoryId,
@@ -19,10 +21,10 @@ public record CreatePotRequest(
         String content
 ) {
 
-    public static Pot toPot(CreatePotRequest createPotRequest, Long userId) {
+    public static Pot toPot(CreatePotRequest createPotRequest, User user, Category category) {
         return Pot.builder()
-                .categoryId(createPotRequest.categoryId())
-                .userId(userId)
+                .category(category)
+                .user(user)
                 .imageKey(createPotRequest.imageKey())
                 .potType(createPotRequest.type())
                 .content(

--- a/src/main/java/org/com/itpple/spot/server/dto/pot/response/CreatePotResponse.java
+++ b/src/main/java/org/com/itpple/spot/server/dto/pot/response/CreatePotResponse.java
@@ -23,7 +23,7 @@ public record CreatePotResponse(
         return CreatePotResponse.builder()
                 .id(pot.getId())
                 .userId(pot.getUser().getId())
-                .categoryId(pot.getCategoryId())
+                .categoryId(pot.getCategory().getId())
                 .type(pot.getPotType())
                 .content(pot.getContent())
                 .imageKey(pot.getImageKey())

--- a/src/main/java/org/com/itpple/spot/server/entity/Pot.java
+++ b/src/main/java/org/com/itpple/spot/server/entity/Pot.java
@@ -41,15 +41,9 @@ public class Pot extends BasicDateEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "user_id", insertable = false, updatable = false)
-    private Long userId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
-
-    @Column(name = "category_id", insertable = false, updatable = false)
-    private Long categoryId;
 
     @Column(name = "pot_type", nullable = false)
     @Enumerated(value = EnumType.STRING)

--- a/src/test/java/org/com/itpple/spot/server/service/PotServiceTest.java
+++ b/src/test/java/org/com/itpple/spot/server/service/PotServiceTest.java
@@ -58,16 +58,16 @@ public class PotServiceTest {
         Long categoryId = 1L;
         when(potRepository.findByLocationAndCategoryForAdmin(searchRange.polygon(), 1L)).thenReturn(
                 List.of(
-                        Pot.builder().id(1L).user(user).category(category).categoryId(1L)
+                        Pot.builder().id(1L).user(user).category(category)
                                 .imageKey("test.jpg").potType(
                                         PotType.IMAGE).location(createPoint(new PointDTO(2.0, 2.0)))
                                 .expiredAt(
                                         LocalDateTime.now().plusDays(1)).build(),
-                        Pot.builder().id(2L).user(user).category(category).categoryId(1L)
+                        Pot.builder().id(2L).user(user).category(category)
                                 .imageKey("test.jpg").potType(
                                         PotType.IMAGE).location(createPoint(new PointDTO(2.0, 2.0)))
                                 .expiredAt(LocalDateTime.now().plusDays(1)).build(),
-                        Pot.builder().id(3L).user(user).category(category).categoryId(1L)
+                        Pot.builder().id(3L).user(user).category(category)
                                 .imageKey("test.jpg").potType(
                                         PotType.IMAGE).location(createPoint(new PointDTO(2.0, 2.0)))
                                 .expiredAt(LocalDateTime.now().plusDays(1)).build()
@@ -85,7 +85,7 @@ public class PotServiceTest {
         //given
         when(potRepository.findByLocationAndCategoryId(any(Polygon.class), anyLong())).thenReturn(
                 List.of(
-                        Pot.builder().id(1L).user(user).category(category).categoryId(1L)
+                        Pot.builder().id(1L).user(user).category(category)
                                 .imageKey("test.jpg")
                                 .potType(
                                         PotType.IMAGE).location(createPoint(new PointDTO(1.0, 2.0)))


### PR DESCRIPTION
## 🗃 Issue

- Close #60

## 🔥 Task

- pot 저장 시 user 및 category 제대로 저장하게 변경

## 📄 Reference

- None
