### PR TITLE
[feat] POT 조회 데이터에 반응 데이터 추가

### DIFF
--- a/src/main/java/org/com/itpple/spot/server/domain/pot/dto/PotDTO.java
+++ b/src/main/java/org/com/itpple/spot/server/domain/pot/dto/PotDTO.java
@@ -1,13 +1,15 @@
 package org.com.itpple.spot.server.domain.pot.dto;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.com.itpple.spot.server.domain.location.dto.PointDTO;
 import org.com.itpple.spot.server.domain.pot.entity.Pot;
+import org.com.itpple.spot.server.domain.reaction.dto.ReactionTypeCount;
 import org.com.itpple.spot.server.global.common.constant.PotType;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * response 반환용 뿐 아니라 다른 서비스에서 사용할 수 있도록 DTO로 분리
@@ -27,7 +29,9 @@ public class PotDTO {
     private final LocalDateTime expiredAt;
     private final List<HashtagDTO> hashtagList;
     private final Long viewCount;
-    public static PotDTO from(Pot pot) {
+    private final List<ReactionTypeCount> reactionTypeCounts;
+
+    public static PotDTO from(Pot pot, List<ReactionTypeCount> reactionTypeCounts) {
         return PotDTO.builder()
                 .id(pot.getId())
                 .userId(pot.getUser().getId())
@@ -41,6 +45,11 @@ public class PotDTO {
                         .map(potHashtag -> HashtagDTO.from(potHashtag.getHashtag())
                         ).toList())
                 .viewCount(pot.getViewCount())
+                .reactionTypeCounts(reactionTypeCounts)
                 .build();
+    }
+
+    public static PotDTO from(Pot pot) {
+        return from(pot, null);
     }
 }

--- a/src/main/java/org/com/itpple/spot/server/domain/pot/service/impl/PotServiceImpl.java
+++ b/src/main/java/org/com/itpple/spot/server/domain/pot/service/impl/PotServiceImpl.java
@@ -16,6 +16,7 @@ import org.com.itpple.spot.server.domain.pot.dto.response.UploadImageResponse;
 import org.com.itpple.spot.server.domain.pot.entity.Pot;
 import org.com.itpple.spot.server.domain.pot.repository.PotRepository;
 import org.com.itpple.spot.server.domain.pot.service.PotService;
+import org.com.itpple.spot.server.domain.reaction.repository.ReactionRepository;
 import org.com.itpple.spot.server.domain.user.repository.UserRepository;
 import org.com.itpple.spot.server.global.exception.BusinessException;
 import org.com.itpple.spot.server.global.exception.code.ErrorCode;
@@ -42,6 +43,7 @@ public class PotServiceImpl implements PotService {
     private final UserRepository userRepository;
     private final HashtagRepository hashtagRepository;
     private final ViewHistoryRepository viewHistoryRepository;
+    private final ReactionRepository reactionRepository;
 
     @Override
     public GetCategoryResponse getCategory() {
@@ -120,7 +122,7 @@ public class PotServiceImpl implements PotService {
                         pot.addViewCount();
                         this.createViewHistory(userId, pot);
                     }
-                    return PotDTO.from(pot);
+                    return PotDTO.from(pot, reactionRepository.countEachReactionType(potId));
                 })
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_POT));
     }

--- a/src/main/java/org/com/itpple/spot/server/domain/reaction/dto/ReactionTypeCount.java
+++ b/src/main/java/org/com/itpple/spot/server/domain/reaction/dto/ReactionTypeCount.java
@@ -1,0 +1,10 @@
+package org.com.itpple.spot.server.domain.reaction.dto;
+
+import org.com.itpple.spot.server.global.common.constant.ReactionType;
+
+public interface ReactionTypeCount {
+
+    ReactionType getReactionType();
+
+    Integer getCount();
+}

--- a/src/main/java/org/com/itpple/spot/server/domain/reaction/repository/ReactionRepository.java
+++ b/src/main/java/org/com/itpple/spot/server/domain/reaction/repository/ReactionRepository.java
@@ -1,11 +1,22 @@
 package org.com.itpple.spot.server.domain.reaction.repository;
 
 import org.com.itpple.spot.server.domain.pot.entity.Pot;
+import org.com.itpple.spot.server.domain.reaction.dto.ReactionTypeCount;
 import org.com.itpple.spot.server.domain.reaction.entity.Reaction;
 import org.com.itpple.spot.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
     boolean existsByPotAndUser(Pot pot, User user);
+
+    @Query("SELECT r.reactionType AS reactionType, COUNT(*) AS count " +
+            "FROM Reaction r " +
+            "WHERE r.pot.id = :potId " +
+            "GROUP BY r.reactionType")
+    List<ReactionTypeCount> countEachReactionType(@Param("potId") Long potId);
 }

--- a/src/test/java/org/com/itpple/spot/server/domain/pot/api/PotControllerTest.java
+++ b/src/test/java/org/com/itpple/spot/server/domain/pot/api/PotControllerTest.java
@@ -1,20 +1,7 @@
 package org.com.itpple.spot.server.domain.pot.api;
 
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.com.itpple.spot.server.domain.location.dto.PointDTO;
 import org.com.itpple.spot.server.domain.pot.domain.hashtag.service.HashtagService;
 import org.com.itpple.spot.server.domain.pot.dto.PotDTO;
@@ -33,6 +20,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = PotController.class)
 class PotControllerTest {
@@ -111,11 +110,11 @@ class PotControllerTest {
 
     private final List<PotDTO> potDTOList = (List.of(
             new PotDTO(1L, 1L, List.of(1L), PotType.IMAGE, null, new PointDTO(2.0, 2.0), "test.jpg",
-                    LocalDateTime.now().plusDays(1), List.of(),0L),
+                    LocalDateTime.now().plusDays(1), List.of(), 0L, null),
             new PotDTO(2L, 1L, List.of(1L), PotType.IMAGE, null, new PointDTO(2.0, 2.0), "test.jpg",
-                    LocalDateTime.now().plusDays(1), List.of(),0L),
+                    LocalDateTime.now().plusDays(1), List.of(), 0L, null),
             new PotDTO(3L, 1L, List.of(1L), PotType.IMAGE, null, new PointDTO(2.0, 2.0), "test.jpg",
-                    LocalDateTime.now().plusDays(1), List.of(),0L)
+                    LocalDateTime.now().plusDays(1), List.of(), 0L, null)
     ));
 
     @Test

--- a/src/test/java/org/com/itpple/spot/server/domain/reaction/repository/ReactionRepositoryTest.java
+++ b/src/test/java/org/com/itpple/spot/server/domain/reaction/repository/ReactionRepositoryTest.java
@@ -1,13 +1,9 @@
 package org.com.itpple.spot.server.domain.reaction.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import static org.springframework.test.context.TestConstructor.AutowireMode;
-
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.com.itpple.spot.server.domain.pot.domain.category.entity.Category;
 import org.com.itpple.spot.server.domain.pot.entity.Pot;
+import org.com.itpple.spot.server.domain.reaction.dto.ReactionTypeCount;
 import org.com.itpple.spot.server.domain.reaction.entity.Reaction;
 import org.com.itpple.spot.server.domain.user.entity.User;
 import org.com.itpple.spot.server.global.common.constant.ReactionType;
@@ -22,6 +18,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import static org.springframework.test.context.TestConstructor.AutowireMode;
+
 @RequiredArgsConstructor
 @TestConstructor(autowireMode = AutowireMode.ALL)
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -29,38 +31,68 @@ import org.springframework.test.context.TestConstructor;
 @DataJpaTest
 class ReactionRepositoryTest {
 
-	private final ReactionRepository sut;
-	private final TestEntityManager testEntityManager;
+    private final ReactionRepository sut;
+    private final TestEntityManager testEntityManager;
 
-	private final User user = UserTestUtil.create();
-	private final Category category = PotTestUtil.createCategory();
-	private final Pot pot = PotTestUtil.create(user, category);
-	private final ReactionType REACTION_TYPE = ReactionType.GOOD;
+    private final User user = UserTestUtil.create();
+    private final Category category = PotTestUtil.createCategory();
+    private final Pot pot = PotTestUtil.create(user, category);
 
-	@BeforeEach
-	public void setUp() {
-		testEntityManager.persist(user);
-		testEntityManager.persist(category);
-		testEntityManager.persist(pot);
-	}
+    @BeforeEach
+    public void setUp() {
+        testEntityManager.persist(user);
+        testEntityManager.persist(category);
+        testEntityManager.persist(pot);
+    }
 
-	@Test
-	void 추가한_반응을_조회할_때_isDeleted가_false인_것만_조회된다() {
-		// given
-		List<Reaction> reactionList = List.of(
-			ReactionTestUtil.create(pot, user, REACTION_TYPE, false),
-			ReactionTestUtil.create(pot, user, REACTION_TYPE, true),
-			ReactionTestUtil.create(pot, user, REACTION_TYPE, true),
-			ReactionTestUtil.create(pot, user, REACTION_TYPE, false),
-			ReactionTestUtil.create(pot, user, REACTION_TYPE, false)
-		);
-		sut.saveAll(reactionList);
-		testEntityManager.flush();
+    @Test
+    void 추가한_반응을_조회할_때_isDeleted가_false인_것만_조회된다() {
+        // given
+        List<Reaction> reactionList = List.of(
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, true),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, true),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false)
+        );
+        sut.saveAll(reactionList);
+        testEntityManager.flush();
 
-		// when
-		List<Reaction> actualReactionList = sut.findAll();
+        // when
+        List<Reaction> actualReactionList = sut.findAll();
 
-		// then
-		assertThat(actualReactionList.size()).isEqualTo(3);
-	}
+        // then
+        assertThat(actualReactionList.size()).isEqualTo(3);
+    }
+
+    @Test
+    void ReactionType을_그룹화해_각_반응_타입과_개수를_반환한다() {
+        // given
+        List<Reaction> reactionList = List.of(
+            ReactionTestUtil.create(pot, user, ReactionType.SMILE, false),
+            ReactionTestUtil.create(pot, user, ReactionType.SAD, false),
+            ReactionTestUtil.create(pot, user, ReactionType.ANGRY, false),
+            ReactionTestUtil.create(pot, user, ReactionType.ANGRY, false),
+            ReactionTestUtil.create(pot, user, ReactionType.HEART, false),
+            ReactionTestUtil.create(pot, user, ReactionType.HEART, false),
+            ReactionTestUtil.create(pot, user, ReactionType.HEART, false),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false),
+            ReactionTestUtil.create(pot, user, ReactionType.GOOD, false)
+        );
+        sut.saveAll(reactionList);
+        testEntityManager.flush();
+
+        // when
+        List<ReactionTypeCount> reactionTypeCountList = sut.countEachReactionType(pot.getId());
+
+        // then
+        for (ReactionTypeCount reactionTypeCount : reactionTypeCountList) {
+            switch (reactionTypeCount.getReactionType()) {
+                case SMILE, SAD -> assertThat(reactionTypeCount.getCount()).isEqualTo(1);
+                case ANGRY -> assertThat(reactionTypeCount.getCount()).isEqualTo(2);
+                case HEART, GOOD -> assertThat(reactionTypeCount.getCount()).isEqualTo(3);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🗃 Issue

- Close #91 

## 🔥 Task

- POT 조회 데이터에 reactionType를 그룹화해 각 타입과 개수에 대한 데이터를 추가합니다. 

## 📄 Reference

- None
